### PR TITLE
Avoid nginx version disclosure

### DIFF
--- a/nginx-site.conf
+++ b/nginx-site.conf
@@ -10,6 +10,7 @@ tcp_nodelay off;
 client_header_timeout ${CLIENT_HEADER_TIMEOUT}s;
 client_body_timeout ${CLIENT_BODY_TIMEOUT}s;
 client_max_body_size ${CLIENT_MAX_BODY_SIZE}k;
+server_tokens off;
 reset_timedout_connection on;
 
 gzip_types


### PR DESCRIPTION
Not turning off `server_tokens` might lead to sensitive information disclosure, which then might ease flaws identifications by malicious attackers.